### PR TITLE
Add RustChain (experimental layer-1 chain)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -7952,6 +7952,15 @@ projects:
     category: None
     labels: ["bsc"]
 
+  - group: true
+    group_id: rtc
+    name: RTC - RustChain
+    homepage: https://rustchain.org
+    description: Proof-of-Antiquity blockchain that rewards vintage and exotic hardware
+      (PowerPC, SPARC, 68K, POWER8) with higher mining multipliers. Features hardware
+      fingerprint attestation (RIP-PoA), Ergo anchoring, and time-aged antiquity bonuses.
+    category: cryptocurrency
+
   # Projects
   - name: vyper
     github_id: vyperlang/vyper
@@ -18330,3 +18339,12 @@ projects:
   - name: ExzoCoin
     github_id: ExzoNetwork/ExzoCoin
     group_id: exzo
+  - name: Rustchain
+    github_id: Scottcjn/Rustchain
+    group_id: rtc
+  - name: bottube
+    github_id: Scottcjn/bottube
+    group_id: rtc
+  - name: ram-coffers
+    github_id: Scottcjn/ram-coffers
+    group_id: rtc


### PR DESCRIPTION
Adds RustChain as a single project entry.

RustChain is an experimental layer-1 chain with Proof-of-Antiquity consensus. Hardware fingerprint attestation (clock drift, cache timing, SIMD identity, thermal entropy, instruction jitter and anti-emulation checks) verifies that a node is real physical hardware rather than a VM or emulator, and older machines such as PowerPC G4 and G5, SPARC, 68K and IBM POWER8 carry more weight in consensus. Attestation data is anchored to Ergo.

I've listed it without a category because it isn't a token project and none of the existing categories fit a layer-1 chain like this. Happy to move it if you prefer a different placement.

Disclosure: submitted by an Elyan Labs account; Elyan Labs builds RustChain.
